### PR TITLE
Fixes Issue 1: Backend crashes when token fetch fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 config/data.json
+yarn.lock
+*.swp
 

--- a/backend/src/lib/postcard.js
+++ b/backend/src/lib/postcard.js
@@ -63,9 +63,14 @@ function authorize(user, pw, success, error) {
  * @param {function} callbacks.success - Callback for success
  */
 function sendPostcard(user, pw, recipient, assetStream, message, callbacks) { // eslint-disable-line max-params
-  authorize(user, pw, (token) => {
-    _sendPostcard(token, recipient, assetStream, message, callbacks)
-  })
+  authorize(
+    user,
+    pw,
+    (token) => {
+      _sendPostcard(token, recipient, assetStream, message, callbacks)
+    },
+    callbacks['error']
+  )
 }
 
 export default sendPostcard

--- a/backend/src/lib/postcard.js
+++ b/backend/src/lib/postcard.js
@@ -44,7 +44,7 @@ function authorize(user, pw, success, error) {
   SSOHelper.getPostcardcreatorToken(
     user, pw, (err, token) => {
       if (err) {
-        if (typeof error !== undefined) {
+        if (error) {
           error(`Unable to get token: ${err}`)
         }
       }

--- a/backend/src/lib/postcard.js
+++ b/backend/src/lib/postcard.js
@@ -37,7 +37,8 @@ function _sendPostcard(token, recipient, assetStream, message, callbacks) { // e
 /**
  * @param {string} user - Username
  * @param {string} pw - Password
- * @param {function} callback - Call when the auth was successful
+ * @param {function} success - Call when the auth was successful
+ * @param {function} error - Call when the auth failed
  */
 function authorize(user, pw, success, error) {
   SSOHelper.getPostcardcreatorToken(

--- a/backend/src/lib/postcard.js
+++ b/backend/src/lib/postcard.js
@@ -46,6 +46,7 @@ function authorize(user, pw, success, error) {
       if (err) {
         if (error) {
           error(`Unable to get token: ${err}`)
+          return
         }
       }
       success(token)


### PR DESCRIPTION
I just fixed the error I described in #1 .

The ember app now receives the error message immediately instead of waiting for the timeout, and displays a more useful error.
However, the backend still crashes. I haven't figured out yet why, so here's the PR ;).
 
```
** ERROR ** on users.current()  { status: 401, message: 'Unable to complete HTTP request' }
/home/bigboss/projects/postcardy/backend/node_modules/q/q.js:155
                throw e;
                ^

Error: Can't set headers after they are sent.
    at ServerResponse.setHeader (_http_outgoing.js:359:11)
    at ServerResponse.header (/home/bigboss/projects/postcardy/backend/node_modules/express/lib/response.js:719:10)
    at ServerResponse.send (/home/bigboss/projects/postcardy/backend/node_modules/express/lib/response.js:164:12)
    at ServerResponse.json (/home/bigboss/projects/postcardy/backend/node_modules/express/lib/response.js:250:15)
    at Object.error (/home/bigboss/projects/postcardy/backend/src/routes/api/v1/postcard.js:36:15)
    at /home/bigboss/projects/postcardy/backend/src/lib/postcard.js:27:17
    at /home/bigboss/projects/postcardy/backend/node_modules/q/q.js:2031:17
    at runSingle (/home/bigboss/projects/postcardy/backend/node_modules/q/q.js:137:13)
    at flush (/home/bigboss/projects/postcardy/backend/node_modules/q/q.js:125:13)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
[nodemon] app crashed - waiting for file changes before starting...
```